### PR TITLE
Fix docker build by installing git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM continuumio/miniconda3:latest AS builder
 
 # Install system dependencies
 RUN apt-get update && \
-    apt-get install -y sudo libusb-1.0 gcc g++ python3-dev && \
+    apt-get install -y sudo libusb-1.0 gcc g++ python3-dev git && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/hummingbot


### PR DESCRIPTION
## Summary
- install git in the Docker build stage so pip can pull git-based dependencies

## Testing
- not run (docker not available in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68ee954b53348325b50bc4ba83ecfa96