### PR TITLE
Fix pandas_ta version to unblock Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM continuumio/miniconda3:latest AS builder
 
 # Install system dependencies
 RUN apt-get update && \
-    apt-get install -y sudo libusb-1.0 gcc g++ python3-dev && \
+    apt-get install -y sudo libusb-1.0 gcc g++ python3-dev git && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/hummingbot

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ def main():
         "web3",
         "websockets",
         "yarl",
-        "pandas_ta==0.3.14b",
+        "pandas_ta==0.3.14b0",
         "xrpl-py==4.0.0b3",
     ]
 

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -54,7 +54,7 @@ dependencies:
     - jsonpickle==3.0.1
     - mypy-extensions==0.4.3
     - msgpack
-    - pandas_ta==0.3.14b
+    - pandas_ta==0.3.14b0
     - pre-commit==2.18.1
     - psutil==5.7.2
     - ptpython==3.0.20

--- a/setup/environment_dydx.yml
+++ b/setup/environment_dydx.yml
@@ -51,7 +51,7 @@ dependencies:
     - jsonpickle==3.0.1
     - mypy-extensions==0.4.3
     - msgpack
-    - pandas_ta==0.3.14b
+    - pandas_ta==0.3.14b0
     - pre-commit==2.18.1
     - psutil==5.7.2
     - ptpython==3.0.20


### PR DESCRIPTION
## Summary
- update pandas_ta dependency pin to the published 0.3.14b0 release across setup and conda environments to restore Docker image builds

## Testing
- not run (docker not available in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68ee954b53348325b50bc4ba83ecfa96